### PR TITLE
:wrench: Allow to set the API Gateway URL via environment configuration when using the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ RUN npm run build
 
 # production environment
 FROM nginx:1.23.1-alpine
+RUN apk add --no-cache jq
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+ENV INDEX /usr/share/nginx/html/index.html
 
 COPY --from=build /app/build /usr/share/nginx/html
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
 
 ![Partial screenshot of the Web UI](cleanURI-screenshot.png)
 
+
+## Configuration
+
+The Docker container can be configured using environment variables:
+
+* `REACT_APP_API_GATEWAY`: URL to the API Gateway (default: `http://localhost:8080`)
+
+Please note that this configuration is not available when the app is run locally. In this case configuration variables will have their default values.
+
+
 ## Development
 
 The Web UI is based on [React](https://reactjs.org/) and requires [NodeJS](https://nodejs.org/en/) > 14.
@@ -49,9 +59,12 @@ An HTTP daemon serving the static content can be run as follows:
 
 ```bash
 docker run --rm \
+  -e REACT_APP_API_GATEWAY="api gateway uri" \
   -p 8080:80 \
   mrtux/cleanuri-webui
 ```
+
+Note that the default API gateway points at `http://localhost:8080/` and therefore will not be available in the Docker container. Please don't forget to set a working URL for the API Gateway here.
 
 ### Build with npm
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -euo pipefail
+
+# Capture all environment variables starting with REACT_APP_ and make JSON string from them
+ENV_JSON="$(jq --compact-output --null-input 'env | with_entries(select(.key | startswith("REACT_APP_")))')"
+
+# Escape sed replacement's special characters: \, &, /.
+# No need to escape newlines, because --compact-output already removed them.
+# Inside of JSON strings newlines are already escaped.
+ENV_JSON_ESCAPED="$(printf "%s" "${ENV_JSON}" | sed -e 's/[\&/]/\\&/g')"
+
+sed -i "s/<noscript id=\"env-insertion-point\"><\/noscript>/<script>var ENV=${ENV_JSON_ESCAPED}<\/script>/g" "$INDEX"
+
+exec "$@"

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
       content="WebUI for the cleanURI service."
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <noscript id="env-insertion-point"></noscript>
     <title>cleanURI</title>
   </head>
   <body>

--- a/src/CleanUriForm.js
+++ b/src/CleanUriForm.js
@@ -4,7 +4,16 @@ import DecoratedList from './DecoratedList';
 import ErrorList from './ErrorList';
 import UriInputForm from './UriInputForm';
 
-const api = "http://localhost:8080/"
+
+const getApiGateway = function() {
+    const default_api = "http://localhost:8080/"
+
+    return (
+        window.ENV && window.ENV.REACT_APP_API_GATEWAY 
+        ? window.ENV.REACT_APP_API_GATEWAY + "/"
+        : default_api
+    );
+}
 
 class CleanUriForm extends React.Component {
     constructor(props) {
@@ -32,7 +41,7 @@ class CleanUriForm extends React.Component {
             this.onUriChange(uri);
         }
 
-        const url = api + 'reduce?meta=IT&uri=' + encodeURIComponent(requestUri);
+        const url = getApiGateway() + 'reduce?meta=IT&uri=' + encodeURIComponent(requestUri);
         fetch(url, {
             mode: 'cors'
         })


### PR DESCRIPTION
This mostly follows an idea outlined by https://github.com/axelhzf/create-react-app-docker-environment-variables