### PR TITLE
📦 Limit code highlighter so json

### DIFF
--- a/src/DecoratedList.js
+++ b/src/DecoratedList.js
@@ -5,7 +5,7 @@ import common_css from './common.css';
 import React from 'react';
 import DecoratedResult from './DecoratedResult';
 import { LightAsync as SyntaxHighlighter } from 'react-syntax-highlighter';
-
+import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
 import { github } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 github['hljs']['background'] = common_css['--result-background'];
 
@@ -64,6 +64,7 @@ class DecoratedList extends React.Component {
     } 
 
     renderJsonResultItem(message) {
+        SyntaxHighlighter.registerLanguage('json', json);
         return (
             <SyntaxHighlighter
                     language="json" 


### PR DESCRIPTION
I tried to use the method described [here](https://github.com/react-syntax-highlighter/react-syntax-highlighter#light-build).
Code runs, but without a complete setup i can't verify, that it still works as intended.