### PR TITLE
:construction_worker: Fix checkout for the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: "Check-out"
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: "Generate release changelog"
         id: generate-release-changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3


### PR DESCRIPTION
Apparently the checkout action changed its default behaviour with one of the updates and the fetch depth now needs to be explicitly set if more than the latest commit is desired. 

This PR fixes the configuration for the checkout action so that the changelog can be built again.