### PR TITLE
:green_heart: Directly hand over GitHub secrets

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -20,4 +20,7 @@ jobs:
       - call-nodejs-test
     with:
       image: mrtux/cleanuri-webui
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+


### PR DESCRIPTION
Apparently the `inherit` directive does not work (anymore). Directly hand over the secrets to the Docker workflow to fix CI issues.