### PR TITLE
Fix the node build platform to linux/amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build environment
-FROM node:24.4.1-alpine3.21 AS build
+FROM --platform=linux/amd64 node:24.4.1-alpine3.21 AS build_amd64
 
 WORKDIR /app
 
@@ -13,6 +13,11 @@ RUN npm --no-audit --no-fund ci
 COPY . ./
 
 RUN npm run build
+
+
+# This is here to satiyfy
+# https://docs.docker.com/reference/build-checks/from-platform-flag-const-disallowed/
+FROM build_amd64 as build
 
 
 # production environment


### PR DESCRIPTION
node:24.4.1-alpine3.21 is not available for all viable target platforms. Fix to linux/amd64 to mitigate this issue, as the build artifacts are not platform-dependend.