### PR TITLE
Disable Dependabot groups for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,3 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"


### PR DESCRIPTION
These groups lead to problems with incompatible dependencies which are hard to resolve in grouped updates. Switch back to individual update PRs, which can be aggregated via cherry-pick.