### PR TITLE
Add docker compose file for local tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ docker run --rm \
 
 Note that the default API gateway points at `http://localhost:8080/` and therefore will not be available in the Docker container. Please don't forget to set a working URL for the API Gateway here.
 
+### Run with Docker Compose (Development)
+
+To run with [docker compose](https://docs.docker.com/compose/) copy  [`.env.template`](.env.template) to `.env` and edit the necessary variables. Then start with:
+
+```bash
+docker compose up --build
+```
+
+Please note that this compose file will rebuild the image based on the repository. This is helpful during development and not intended for production use.
+
+When done, please don't forget to remove the deployment with
+```bash
+docker compose down
+```
+
 ### Build with npm
 
 In the project directory, you can run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# Do not forget to create the .env file (see template)
+# before using this container!
+
+services:
+  www:
+    restart: always
+    build: .
+    environment:
+      PORT: $PORT
+      REACT_APP_API_GATEWAY: $REACT_APP_API_GATEWAY
+    ports:
+      - $PORT:80


### PR DESCRIPTION
This pull request adds support for running the application in a development environment using Docker Compose. The most important changes are the addition of a `docker-compose.yml` file and updated documentation to guide users through the new workflow.

**Docker Compose support:**

* Added a new `docker-compose.yml` file that defines a `www` service, sets up environment variables, and maps ports for local development.

**Documentation updates:**

* Updated `README.md` with instructions for running the application using Docker Compose, including steps for copying the `.env.template`, building, starting, and stopping the service.