### PR TITLE
Replace dependency react-github-fork-ribbon by github-fork-ribbon-css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "github-fork-ribbon-css": "^0.2.3",
         "react": "^18.2.0",
         "react-copy-to-clipboard-ts": "^1.3.0",
         "react-dom": "^18.2.0",
-        "react-github-fork-ribbon": "^0.7.1",
         "react-syntax-highlighter": "^15.6.1",
         "web-vitals": "^5.1.0"
       },
@@ -2041,6 +2041,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/github-fork-ribbon-css": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/github-fork-ribbon-css/-/github-fork-ribbon-css-0.2.3.tgz",
+      "integrity": "sha512-cmGBV4sivRwmnteSOkqMjN2cnP5/J1SU5aDCVYsBWHmDokZ/JjwGEkduCxY9IULHdCPpw1WSk5Cy8N1LF6jOEw=="
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2779,17 +2784,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-github-fork-ribbon": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/react-github-fork-ribbon/-/react-github-fork-ribbon-0.7.1.tgz",
-      "integrity": "sha512-buxFTLteR83jHGDiJfukS5AevEzGszHpjXyPAMn3+saHeOJa3FAAHdlQuWVjyVLPejs2aNqHTNRGkHXwO/1A4A==",
-      "engines": {
-        "node": ">=0.10.x"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "github-fork-ribbon-css": "^0.2.3",
     "react": "^18.2.0",
     "react-copy-to-clipboard-ts": "^1.3.0",
     "react-dom": "^18.2.0",
-    "react-github-fork-ribbon": "^0.7.1",
     "react-syntax-highlighter": "^15.6.1",
     "web-vitals": "^5.1.0"
   },

--- a/src/main.css
+++ b/src/main.css
@@ -14,3 +14,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.github-fork-ribbon:before {
+    background-color: orange !important;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,20 +3,15 @@ import ReactDOM from 'react-dom/client';
 import './main.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import GitHubForkRibbon from 'react-github-fork-ribbon';
-
+import 'github-fork-ribbon-css/gh-fork-ribbon.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <GitHubForkRibbon href="https://github.com/penguineer/cleanURI"
-		      target="_blank"
-                      position="right"
-                      color="orange">
-      Fork me on GitHub
-    </GitHubForkRibbon>
-    <App />
-  </React.StrictMode>
+    <React.StrictMode>
+        <a className="github-fork-ribbon" href="https://github.com/penguineer/cleanURI" data-ribbon="Fork me on GitHub"
+           title="Fork me on GitHub" rel='noopener noreferrer' target="_blank" />
+        <App/>
+    </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
The react dependency is not longer fit for React 19 and the project seems to be abandoned. Replace by the original CSS ribbon, see https://simonwhitaker.github.io/github-fork-ribbon-css/