### PR TITLE
Switch to monthly dependabot checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,18 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"


### PR DESCRIPTION
The change rate suggests a monthly dependabot check, especially since urgent security updates are delivered independently.