### PR TITLE
Group updates for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
+    groups:
+      gitub-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request updates the Dependabot configuration to introduce grouping of GitHub Actions dependency updates. The most important change is the addition of a group for GitHub Actions, which will help manage and organize dependency update PRs more efficiently.

Dependabot configuration improvements:

* Added a `groups` section under the GitHub Actions configuration in `.github/dependabot.yml`, creating a `gitub-actions` group that matches all patterns. This will group all GitHub Actions dependency updates together.